### PR TITLE
chore(deps): add dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+version: 2
+updates:
+  - package-ecosystem: "npm" 
+    directory: "/" 
+    schedule:
+      interval: "weekly" 
+    rebase-strategy: "auto"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+    labels:
+      - "dependencies"
+      - "auto-update"
+    # Ignore certain dependencies or major version updates
+    ignore:
+      - dependency-name: "next"
+        update-types: ["version-update:semver-major"]


### PR DESCRIPTION
Set up Dependabot to auto-track dependency updates in `package.json`.
Defaulting to weekly checks – happy to adjust the schedule or scope if needed.